### PR TITLE
Refactor: Use class-based styling for dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
               </label>
             </div>
             <div class="col-2">
-              <select id="dropdown">
+              <select id="dropdown" class="dropdown-styling">
                 <option value="1">Student</option>
                 <option value="2">Full-Time Job</option>
                 <option value="3">Full-Time Learner</option>
@@ -110,7 +110,7 @@
               </label>
             </div>
             <div class="col-2">
-              <select id="dropdown">
+              <select id="like-dropdown" class="dropdown-styling">
                 <option value="1">Challenges</option>
                 <option value="2">Projects</option>
                 <option value="3">Community</option>

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -43,11 +43,8 @@ body {
   height: 6px;
   width: 60%;
 }
-#dropdown {
+.dropdown-styling {
   height: 33px;
-  width: 60%;
-}
-#like {
   width: 60%;
 }
 #improve-row {


### PR DESCRIPTION
- Added `class="dropdown-styling"` to both select elements in `index.html`.
- Updated `resources/css/main.css` to use the `.dropdown-styling` class for styling dropdowns, removing the previous ID-based rules.

This change improves CSS maintainability and scalability for dropdown styling.